### PR TITLE
Ignore DELETE requests to whipHandler

### DIFF
--- a/main.go
+++ b/main.go
@@ -35,6 +35,10 @@ func logHTTPError(w http.ResponseWriter, err string, code int) {
 }
 
 func whipHandler(res http.ResponseWriter, r *http.Request) {
+	if r.Method == "DELETE" {
+		return
+	}
+
 	streamKey := r.Header.Get("Authorization")
 	if streamKey == "" {
 		logHTTPError(res, "Authorization was not set", http.StatusBadRequest)


### PR DESCRIPTION
Hello, I fixed an issue in upstream that you may be interested in, [PR](https://github.com/Glimesh/broadcast-box/pull/56).

The reason why there streams listed on the status page that we're not active, was due to OBS sending a DELETE request when the stream is closed, this would have the effect of creating a phantom stream. 

This would fix that, so only stream that keys that are actively being streamed to will show up on the status page. Not sure if this would have any knock on effects with some of the patches you created.

Hope this helps
Chase